### PR TITLE
Enable password-less sudo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
           - ubuntu1804
           - ubuntu2004
           - ubuntu2204
-          - debian9
           - debian10
           - debian11
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule[docker] docker
+        run: pip3 install ansible molecule molecule-docker
 
       - name: Run Molecule tests.
         run: molecule test --scenario-name ${{ matrix.scenario }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,14 @@
     update_cache: yes
     cache_valid_time: 3600
 
+- name: Enable passwordless sudo
+  template:
+    src: "passwordless-sudo.j2"
+    dest: "/etc/sudoers.d/passwordless-sudo"
+    owner: root
+    group: root
+    mode: "770"
+
 - name: "Ensure group {{ linux_accounts_group }} exists"
   group:
     name: "{{ linux_accounts_group }}"

--- a/templates/passwordless-sudo.j2
+++ b/templates/passwordless-sudo.j2
@@ -1,0 +1,3 @@
+{% for user in linux_accounts_sudo_users %}
+{{ user }} ALL=(ALL:ALL) NOPASSWD: ALL
+{% endfor %}


### PR DESCRIPTION
This is subject to change, but for now, as we enforce login in using an SSH key, there is not much security added if we also ask for a password.