### PR TITLE
Allow to set multiple keys per user

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ N/A
 
 You need to define the following variable:
 
-* `linux_accounts_default_users`: A dictionary of user account names and their SSH key.
+* `linux_accounts_default_users`: A dictionary of user account names and a list of their SSH keys.
 * `linux_accounts_group`: Name of the group which will be created and users will be added. Note that any users in this group that aren't mentioned in `linux_accounts_default_users` nor `linux_accounts_additional_users` will be deleted.
 * `linux_accounts_default_sudo_users`: List of user names that will be added to the sudo group.
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,11 +8,11 @@
 
   vars:
     linux_accounts_additional_users: {
-      "bob": "bobssshkey"
+      "bob": [ "bobssshkey1", "bobssshkey2" ]
     }
 
     linux_accounts_default_users: {
-      "alice": "alicessshkey"
+      "alice": [ "alicessshkey" ]
     }
 
     linux_accounts_additional_sudo_users:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -2,10 +2,18 @@
 - name: Verify
   hosts: all
   tasks:
-    - name: Check authorized key for Bob
+    - name: Check authorized key 1 for Bob
       lineinfile:
         dest: /home/bob/.ssh/authorized_keys
-        line: bobssshkey
+        line: bobssshkey1
+      check_mode: true
+      register: presence
+      failed_when: presence.changed
+
+    - name: Check authorized key 2 for Bob
+      lineinfile:
+        dest: /home/bob/.ssh/authorized_keys
+        line: bobssshkey2
       check_mode: true
       register: presence
       failed_when: presence.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,7 +49,7 @@
 
 - name: Add authorized key for user accounts
   copy:
-    content: "{{ item.value }}\n"
+    content: "{{ item.value | join('\n') }}\n"
     dest: "~{{ item.key }}/.ssh/authorized_keys"
     owner: "{{ item.key }}"
     group: "{{ item.key }}"


### PR DESCRIPTION
With this PR, a list of public keys can be set per user account. This should help when e.g. rotating SSH keys for a user that automation uses or when a user has multiple machines with different SSH keys. The recommendation is still that a user generally has one SSH key.