### PR TITLE
Allow to keep accounts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,5 @@ linux_accounts_default_users: []
 
 linux_accounts_additional_sudo_users: []
 linux_accounts_default_sudo_users: []
+
+linux_accounts_to_keep: []

--- a/molecule/deletion/molecule.yml
+++ b/molecule/deletion/molecule.yml
@@ -27,6 +27,9 @@ provisioner:
         linux_accounts_additional_sudo_users:
           - "bob"
 
+        linux_accounts_to_keep:
+          - "dave"
+
         linux_accounts_group: "accounts"
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}

--- a/molecule/deletion/prepare.yml
+++ b/molecule/deletion/prepare.yml
@@ -9,7 +9,10 @@
 
     - name: "Create user account to be deleted"
       user:
-        name: "charlie"
+        name: "{{ item }}"
         shell: "/bin/bash"
         groups: "{{ linux_accounts_group }}"
-        append: yes 
+        append: yes
+      loop:
+        - "charlie"
+        - "dave"

--- a/molecule/deletion/verify.yml
+++ b/molecule/deletion/verify.yml
@@ -12,3 +12,9 @@
       assert:
         that:
           - "ansible_facts.getent_passwd['charlie'] == None"
+
+    - name: Get information about user "dave" to check if still present
+      getent:
+        database: passwd
+        fail_key: true
+        key: dave

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,7 @@
   loop: "{{ lookup('ansible.builtin.dict', linux_accounts_users) }}"
 
 - name: Grant sudo privileges
-  user: 
+  user:
     name: "{{ item }}"
     groups: sudo
     append: yes
@@ -58,7 +58,7 @@
 - name: Get group informations
   ansible.builtin.getent:
     database: group
-    split: ':'
+    split: ":"
 
 - name: "Get users in {{ linux_accounts_group }} group"
   set_fact:
@@ -69,7 +69,7 @@
     accounts_to_be_removed: "{{ users_in_group | reject('in', (linux_accounts_users.keys()|list)) }}"
 
 - name: "Remove accounts"
-  user: 
+  user:
     name: "{{ item }}"
     state: absent
-  loop: "{{ accounts_to_be_removed }}"
+  loop: "{{ accounts_to_be_removed | difference(linux_accounts_to_keep) }}"


### PR DESCRIPTION
With this PR, a new option is added that certain accounts can be kept even if they are no longer referenced in `linux_accounts_users`. This is meant as a fail-safe option if you manage existing accounts that should eventually be replaced, but are afraid that they are accidentally deleted.