### PR TITLE
Revoke sudo permissions

### DIFF
--- a/molecule/deletion/molecule.yml
+++ b/molecule/deletion/molecule.yml
@@ -22,7 +22,7 @@ provisioner:
       all:
         linux_accounts_additional_users: { "bob": "bobssshkey" }
 
-        linux_accounts_default_users: { "alice": "alicessshkey" }
+        linux_accounts_default_users: { "alice": "alicessshkey", "erwin": "erwinsshkey" }
 
         linux_accounts_additional_sudo_users:
           - "bob"

--- a/molecule/deletion/prepare.yml
+++ b/molecule/deletion/prepare.yml
@@ -16,3 +16,10 @@
       loop:
         - "charlie"
         - "dave"
+        - "erwin"
+
+    - name: Grant sudo privileges to erwin
+      user:
+        name: "erwin"
+        groups: sudo
+        append: yes

--- a/molecule/deletion/verify.yml
+++ b/molecule/deletion/verify.yml
@@ -18,3 +18,15 @@
         database: passwd
         fail_key: true
         key: dave
+
+    - name: Get sudo group members
+      getent:
+        database: group
+        key: sudo
+      register: sudo_group
+      changed_when: false
+
+    - name: Assert 'erwin' is not in 'sudo' group
+      assert:
+        that:
+          - "'erwin' not in sudo_group['ansible_facts']['getent_group']['sudo'][2].split(',')"  # Index 2 typically holds the user list for the group.

--- a/molecule/deletion/verify.yml
+++ b/molecule/deletion/verify.yml
@@ -22,11 +22,12 @@
     - name: Get sudo group members
       getent:
         database: group
-        key: sudo
-      register: sudo_group
+      register: group_data
       changed_when: false
 
-    - name: Assert 'erwin' is not in 'sudo' group
+    - name: Assert 'erwin' is in the correct groups
       assert:
         that:
-          - "'erwin' not in sudo_group['ansible_facts']['getent_group']['sudo'][2].split(',')"  # Index 2 typically holds the user list for the group.
+          - "'erwin' in group_data['ansible_facts']['getent_group']['erwin'][2].split(',')"
+          - "'erwin' in group_data['ansible_facts']['getent_group']['accounts'][2].split(',')"
+          - "'erwin' not in group_data['ansible_facts']['getent_group']['sudo'][2].split(',')" # Index 2 typically holds the user list for the group.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,7 +49,7 @@
 
 - name: "Set accounts to revoke sudo permissions"
   set_fact:
-    sudo_to_be_removed: "{{ users_in_sudo_group | reject('in', (linux_accounts_sudo_users)) }}"
+    sudo_to_be_removed: "{{ users_in_sudo_group | difference(linux_accounts_sudo_users) }}"
 
 - name: "Revoke sudo permissions"
   include_tasks: revoke-sudo.yml
@@ -85,7 +85,7 @@
 
 - name: "Set accounts to be removed"
   set_fact:
-    accounts_to_be_removed: "{{ users_in_group | reject('in', (linux_accounts_users.keys()|list)) }}"
+    accounts_to_be_removed: "{{ users_in_group | difference(linux_accounts_users.keys()|list) }}"
 
 - name: "Remove accounts"
   user:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,6 +38,25 @@
     append: yes
   loop: "{{ linux_accounts_sudo_users }}"
 
+- name: Get sudo group informations
+  getent:
+    database: group
+    key: sudo
+
+- name: "Get users in sudo group"
+  set_fact:
+    users_in_sudo_group: "{{ ansible_facts.getent_group['sudo'][2] | split(',') }}"
+
+- name: "Set accounts to revoke sudo permissions"
+  set_fact:
+    sudo_to_be_removed: "{{ users_in_sudo_group | reject('in', (linux_accounts_sudo_users)) }}"
+
+- name: "Revoke sudo permissions"
+  include_tasks: revoke-sudo.yml
+  loop: "{{ sudo_to_be_removed | difference(linux_accounts_sudo_users) }}"
+  loop_control:
+    loop_var: user
+
 - name: "Create .ssh directory for user accounts"
   file:
     path: "~{{ item.key }}/.ssh"

--- a/tasks/revoke-sudo.yml
+++ b/tasks/revoke-sudo.yml
@@ -1,0 +1,10 @@
+- name: Get groups for user '{{ user }}'
+  command: "groups {{ user }}"
+  register: current_groups
+  changed_when: false
+
+- name: Revoke 'sudo' for '{{ user }}'
+  user:
+    name: "{{ user }}"
+    groups: "{{ current_groups.stdout | replace(user + ' : ', '') | replace('sudo', '') | split }}"
+    append: no

--- a/tasks/revoke-sudo.yml
+++ b/tasks/revoke-sudo.yml
@@ -1,10 +1,10 @@
 - name: Get groups for user '{{ user }}'
-  command: "groups {{ user }}"
+  command: "id -nG {{ user }}"
   register: current_groups
   changed_when: false
 
 - name: Revoke 'sudo' for '{{ user }}'
   user:
     name: "{{ user }}"
-    groups: "{{ current_groups.stdout | replace(user + ' : ', '') | replace('sudo', '') | split }}"
+    groups: "{{ current_groups.stdout | replace('sudo', '') | split }}"
     append: no


### PR DESCRIPTION
The role is currently not able to revoke sudo permissions for users. With this PR, this is added. The first commit adds a failing test, while the second one includes the actual implementation.

I'm personally a bit disappointed that Ansible does not have any nice native tools to remove groups on a user. Using `command` to retrieve groups, and then transforming the resulting output feels very hacky. I made a couple of tries with `getent`, but it ended up in a nightmare of Jinja transformations.